### PR TITLE
Use floats to compute background color

### DIFF
--- a/src/pdf_quench.py
+++ b/src/pdf_quench.py
@@ -717,7 +717,7 @@ class MainWindow(Gtk.Window):
     self.__zoom_level = DEFAULT_ZOOM_LEVEL
     self.__canvas = GooCanvas.Canvas()
     self.__canvas.set_scale(ZOOM_LEVELS[DEFAULT_ZOOM_LEVEL])
-    self.__canvas.override_background_color(Gtk.StateType.NORMAL, Gdk.RGBA(240/255,240/255,240/255))
+    self.__canvas.override_background_color(Gtk.StateType.NORMAL, Gdk.RGBA(240.0/255, 240.0/255, 240.0/255))
     self.__dragging = False
 
     frame = Gtk.Frame()


### PR DESCRIPTION
240/255 computes to 0 on python 2 resulting in a black background. Use a float as dividend to get a float as result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tyll/pdf-quench/1)
<!-- Reviewable:end -->
